### PR TITLE
Allow to concatenate .min.js files

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,13 +41,16 @@ function get_js_files (files, opts) {
     var root;
 
     var list = Object.keys(files).filter(function (name) {
-        return (name.match(jsRe) && !name.match(jsMinRe));
+        return name.match(jsRe);
     });
 
     if (opts.filter) {
         list = list.filter(opts.filter);
 
     } else {
+        list = list.filter(function (name) {
+            return !name.match(jsMinRe);
+        });
         root = get_root([], opts);
 
         if (root) {

--- a/index.js
+++ b/index.js
@@ -38,26 +38,22 @@ function get_root (names, opts) {
 }
 
 function get_js_files (files, opts) {
-    var root;
+    var list = Object.keys(files);
+    var root = get_root([], opts);
 
-    var list = Object.keys(files).filter(function (name) {
-        return name.match(jsRe);
-    });
+    if (root) {
+        list = list.filter(function (name) {
+            return (name.indexOf(root) === 0);
+        });
+    }
 
     if (opts.filter) {
         list = list.filter(opts.filter);
 
     } else {
         list = list.filter(function (name) {
-            return !name.match(jsMinRe);
+            return (name.match(jsRe) && !name.match(jsMinRe));
         });
-        root = get_root([], opts);
-
-        if (root) {
-            list = list.filter(function (name) {
-                return (name.indexOf(root) === 0);
-            });
-        }
     }
 
     return list;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -76,7 +76,7 @@ describe('index.js', function () {
         });
     });
 
-    it('filter out everything', function (done) {
+    it('respects options.filter', function (done) {
         var files = make_files();
         var plugin = subject({
             concat: {},


### PR DESCRIPTION
Hi!

I wanted to concatenate a file that was already minified but you can't override the filter default.

> By default .min.js files are excluded.

This PR allows `filter` to override this default.

Let me know what you think. :)